### PR TITLE
Filter all packages by a HashSet before touching the filesystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "railwind",
  "rayon",
  "reqwest",
+ "rustc-hash",
  "serde",
  "toml 0.7.6",
  "tracing",
@@ -2217,6 +2218,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/cli-support/Cargo.toml
+++ b/cli-support/Cargo.toml
@@ -16,6 +16,7 @@ cargo_toml = "0.16.3"
 petgraph = "0.6.3"
 anyhow = "1"
 rayon = "1.7.0"
+rustc-hash = "1.1.0"
 
 # Tailwind
 railwind = "0.1.5"

--- a/cli-support/src/manifest.rs
+++ b/cli-support/src/manifest.rs
@@ -115,14 +115,12 @@ fn collect_dependencies(
     // First find any assets that do have assets. The vast majority of packages will not have any so we can rule them out quickly with a hashset before touching the filesystem
     let mut packages = FxHashSet::default();
     if let Ok(read_dir) = cache_dir.read_dir() {
-        for path in read_dir {
-            if let Ok(path) = path {
-                if path.file_type().unwrap().is_dir() {
-                    let file_name = path.file_name();
-                    let package_name = file_name.to_string_lossy();
-                    if let Some((package_name, _)) = package_name.rsplit_once("-") {
-                        packages.insert(package_name.to_string());
-                    }
+        for path in read_dir.flatten() {
+            if path.file_type().unwrap().is_dir() {
+                let file_name = path.file_name();
+                let package_name = file_name.to_string_lossy();
+                if let Some((package_name, _)) = package_name.rsplit_once('-') {
+                    packages.insert(package_name.to_string());
                 }
             }
         }

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -34,7 +34,7 @@ pub fn package_identifier(package: &str, version: &str) -> String {
 pub fn push_package_cache_dir(package: &str, version: impl Display, dir: &mut PathBuf) {
     let as_string = dir.as_mut_os_string();
     as_string.write_char(std::path::MAIN_SEPARATOR).unwrap();
-    as_string.write_str(&package).unwrap();
+    as_string.write_str(package).unwrap();
     as_string.write_char('-').unwrap();
     as_string.write_fmt(format_args!("{}", version)).unwrap();
 }

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -1,6 +1,9 @@
 //! Utilities for the cache that is used to collect assets
 
-use std::{path::PathBuf, fmt::{Write, Display}, hash::{Hash, Hasher}};
+use std::{
+    fmt::{Display, Write},
+    path::PathBuf,
+};
 
 use home::cargo_home;
 
@@ -28,15 +31,12 @@ pub fn package_identifier(package: &str, version: &str) -> String {
 }
 
 /// Like `package_identifier`, but appends the identifier to the given path
-pub fn push_package_cache_dir(package: &str, version: impl Hash, dir: &mut PathBuf) {
+pub fn push_package_cache_dir(package: &str, version: impl Display, dir: &mut PathBuf) {
     let as_string = dir.as_mut_os_string();
     as_string.write_char(std::path::MAIN_SEPARATOR).unwrap();
     as_string.write_str(&package).unwrap();
     as_string.write_char('-').unwrap();
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    version.hash(&mut hasher);
-    let version = hasher.finish();
-    as_string.write_fmt(format_args!("{:x}", version)).unwrap();
+    as_string.write_fmt(format_args!("{}", version)).unwrap();
 }
 
 pub(crate) fn current_package_version() -> String {


### PR DESCRIPTION
Very few packages will actually have any assets associated with them. This PR changes the asset collection code to read the package name of all the packages with assets that exist in the filesystem and stores it in a HashSet once instead of reaching out to the file system for every package that may have assets associated with it.

This PR makes the performance of [Manganis](https://github.com/DioxusLabs/collect-assets#manganis) good even for crates as large as the main Dioxus repo