### PR TITLE
Switch to the builder pattern for the macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ name = "manganis"
 version = "0.1.0"
 dependencies = [
  "dioxus-core",
+ "manganis-common",
  "manganis-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["assets"]
 
 [dependencies]
 manganis-macro = { path = "./macro" }
+manganis-common = { path = "./common" }
 dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", optional = true }
 
 [workspace]

--- a/macro/src/file.rs
+++ b/macro/src/file.rs
@@ -1,6 +1,6 @@
 use manganis_common::FileAsset;
 use quote::{quote, ToTokens};
-use syn::parse::Parse;
+use syn::{parenthesized, parse::Parse};
 
 use crate::add_asset;
 
@@ -10,7 +10,16 @@ pub struct FileAssetParser {
 
 impl Parse for FileAssetParser {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let path = input.parse::<syn::LitStr>()?;
+        let image = input.parse::<syn::Ident>()?;
+        if image != "file" {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!("Expected file, found {}", image),
+            ));
+        }
+        let inside;
+        parenthesized!(inside in input);
+        let path = inside.parse::<syn::LitStr>()?;
 
         let path_as_str = path.value();
         let path = match path_as_str.parse(){

--- a/macro/src/font.rs
+++ b/macro/src/font.rs
@@ -1,6 +1,6 @@
 use manganis_common::{CssOptions, FileAsset, FileSource};
 use quote::{quote, ToTokens};
-use syn::{braced, bracketed, parse::Parse};
+use syn::{ bracketed, parenthesized, parse::Parse};
 
 use crate::add_asset;
 
@@ -91,18 +91,18 @@ impl ParseFontOptions {
 
 impl Parse for ParseFontOptions {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let inside;
-        braced!(inside in input);
         let mut families = None;
         let mut weights = None;
         let mut text = None;
         let mut display = None;
         loop {
-            if inside.is_empty() {
+            if input.is_empty() {
                 break;
             }
-            let ident = inside.parse::<syn::Ident>()?;
-            let _ = inside.parse::<syn::Token![:]>()?;
+            let _ = input.parse::<syn::Token![.]>()?;
+            let ident = input.parse::<syn::Ident>()?;
+            let inside;
+            parenthesized!(inside in input);
             match ident.to_string().to_lowercase().as_str() {
                 "families" => {
                     families = Some(inside.parse::<FontFamilies>()?);
@@ -123,7 +123,6 @@ impl Parse for ParseFontOptions {
                     ))
                 }
             }
-            let _ = inside.parse::<syn::Token![,]>();
         }
 
         Ok(ParseFontOptions {
@@ -141,6 +140,16 @@ pub struct FontAssetParser {
 
 impl Parse for FontAssetParser {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let image = input.parse::<syn::Ident>()?;
+        if image != "font" {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!("Expected font, found {}", image),
+            ));
+        }
+        let _inside;
+        parenthesized!(_inside in input);
+
         let options = input.parse::<ParseFontOptions>()?;
 
         let url = options.url();

--- a/macro/src/font.rs
+++ b/macro/src/font.rs
@@ -1,6 +1,6 @@
 use manganis_common::{CssOptions, FileAsset, FileSource};
 use quote::{quote, ToTokens};
-use syn::{ bracketed, parenthesized, parse::Parse};
+use syn::{bracketed, parenthesized, parse::Parse};
 
 use crate::add_asset;
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -56,7 +56,7 @@ pub fn classes(input: TokenStream) -> TokenStream {
 ///
 /// # Files
 ///
-/// The file macro collects an arbitrary file. Relative paths are resolved relative to the package root
+/// The file builder collects an arbitrary file. Relative paths are resolved relative to the package root
 /// ```rust
 /// const _: &str = manganis::mg!(file("./src/asset.txt"));
 /// ```
@@ -86,7 +86,7 @@ pub fn classes(input: TokenStream) -> TokenStream {
 ///
 /// # Fonts
 ///
-/// You can use the font macro to collect fonts that will be included in the final binary from google fonts
+/// You can use the font builder to collect fonts that will be included in the final binary from google fonts
 /// ```rust
 /// const _: &str = manganis::mg!(font().families(["Roboto"]));
 /// ```

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -148,7 +148,6 @@ pub fn mg(input: TokenStream) -> TokenStream {
     }
 }
 
-
 struct MetadataValue {
     key: String,
     value: String,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -52,74 +52,102 @@ pub fn classes(input: TokenStream) -> TokenStream {
     .into()
 }
 
-/// You can use the font macro to collect fonts that will be included in the final binary from google fonts
+/// The mg macro collects assets that will be included in the final binary
+///
+/// # Files
+///
+/// The file macro collects an arbitrary file. Relative paths are resolved relative to the package root
 /// ```rust
-/// const _: &str = manganis::font!({ families: ["Roboto"] });
+/// const _: &str = manganis::mg!(file("./src/asset.txt"));
 /// ```
-/// You can specify weights for the fonts
+/// Or you can use URLs to read the asset at build time from a remote location
 /// ```rust
-/// const _: &str = manganis::font!({ families: ["Comfortaa"], weights: [300] });
+/// const _: &str = manganis::mg!(file("https://rustacean.net/assets/rustacean-flat-happy.png"));
 /// ```
-/// Or set the text to only include the characters you need
+///
+/// # Images
+///
+/// You can collect images which will be automatically optimized with the image builder:
 /// ```rust
-/// const _: &str = manganis::font!({ families: ["Roboto"], weights: [200], text: "light font" });
-/// ```
-#[proc_macro]
-pub fn font(input: TokenStream) -> TokenStream {
-    let asset = parse_macro_input!(input as FontAssetParser);
-
-    quote! {
-        #asset
-    }
-    .into_token_stream()
-    .into()
-}
-
-/// You can collect images which will be automatically optimized with the image macro:
-/// ```rust
-/// const _: &str = manganis::image!("./rustacean-flat-gesture.png");
+/// const _: &str = manganis::mg!(image("./rustacean-flat-gesture.png"));
 /// ```
 /// Resize the image at compile time to make the assets file size smaller:
 /// ```rust
-/// const _: &str = manganis::image!("./rustacean-flat-gesture.png", { size: (52, 52) });
+/// const _: &str = manganis::mg!(image("./rustacean-flat-gesture.png").size(52, 52));
 /// ```
 /// Or convert the image at compile time to a web friendly format:
 /// ```rust
-/// const _: &str = manganis::image!("./rustacean-flat-gesture.png", { format: avif, size: (52, 52) });
+/// const _: &str = manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageFormat::Avif).size(52, 52));
 /// ```
 /// You can mark images as preloaded to make them load faster in your app
 /// ```rust
-/// const _: &str = manganis::image!("./rustacean-flat-gesture.png", { preload: true });
+/// const _: &str = manganis::mg!(image("./rustacean-flat-gesture.png").preload());
+/// ```
+///
+/// # Fonts
+///
+/// You can use the font macro to collect fonts that will be included in the final binary from google fonts
+/// ```rust
+/// const _: &str = manganis::mg!(font().families(["Roboto"]));
+/// ```
+/// You can specify weights for the fonts
+/// ```rust
+/// const _: &str = manganis::mg!(font().families(["Roboto"]).weights([200]));
+/// ```
+/// Or set the text to only include the characters you need
+/// ```rust
+/// const _: &str = manganis::mg!(font().families(["Roboto"]).weights([200]).text("Hello, world!"));
 /// ```
 #[proc_macro]
-pub fn image(input: TokenStream) -> TokenStream {
-    let asset = parse_macro_input!(input as ImageAssetParser);
+pub fn mg(input: TokenStream) -> TokenStream {
+    use proc_macro2::TokenStream as TokenStream2;
 
-    quote! {
-        #asset
+    let builder_tokens = {
+        let input = input.clone();
+        parse_macro_input!(input as TokenStream2)
+    };
+
+    let builder_output = quote! {
+        const _: &dyn manganis::ForMgMacro = {
+            use manganis::*;
+            &#builder_tokens
+        };
+    };
+
+    let asset = syn::parse::<ImageAssetParser>(input.clone())
+        .ok()
+        .map(ToTokens::into_token_stream)
+        .or_else(|| {
+            syn::parse::<FontAssetParser>(input.clone())
+                .ok()
+                .map(ToTokens::into_token_stream)
+        })
+        .or_else(|| {
+            syn::parse::<FileAssetParser>(input.clone())
+                .ok()
+                .map(ToTokens::into_token_stream)
+        });
+
+    match asset {
+        Some(asset) => quote! {
+            {
+                #builder_output
+                #asset
+            }
+        }
+        .into_token_stream()
+        .into(),
+        None => quote! {
+            {
+                #builder_output
+                compile_error!("Expected an image, font or file asset")
+            }
+        }
+        .into_token_stream()
+        .into(),
     }
-    .into_token_stream()
-    .into()
 }
 
-/// The file macro collects an arbitrary file. Relative paths are resolved relative to the package root
-/// ```rust
-/// const _: &str = manganis::file!("./src/asset.txt");
-/// ```
-/// You can use URLs to read the asset at build time from a remote location
-/// ```rust
-/// const _: &str = manganis::file!("https://rustacean.net/assets/rustacean-flat-happy.png");
-/// ```
-#[proc_macro]
-pub fn file(input: TokenStream) -> TokenStream {
-    let asset = parse_macro_input!(input as FileAssetParser);
-
-    quote! {
-        #asset
-    }
-    .into_token_stream()
-    .into()
-}
 
 struct MetadataValue {
     key: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,3 +73,86 @@ impl<'a> dioxus_core::prelude::IntoAttributeValue<'a> for ImageAsset {
         dioxus_core::AttributeValue::Text(self.path)
     }
 }
+
+/// A builder for an image asset. This must be used in the `mg!` macro.
+pub struct ImageAssetBuilder;
+
+impl ImageAssetBuilder {
+    /// Sets the preview of the image
+    #[allow(unused)]
+    pub const fn format(self, format: manganis_common::ImageType) -> Self {
+        Self
+    }
+
+    /// Sets the size of the image
+    #[allow(unused)]
+    pub const fn size(self, size: Option<manganis_common::ImageType>) -> Self {
+        Self
+    }
+
+    /// Make the image use a low quality preview
+    #[allow(unused)]
+    pub const fn low_quality_preview(self) -> Self {
+        Self
+    }
+
+    /// Make the image preloaded
+    #[allow(unused)]
+    pub const fn preload(self) -> Self {
+        Self
+    }
+
+    /// Make the image URL encoded
+    #[allow(unused)]
+    pub const fn url_encoded(self) -> Self {
+        Self
+    }
+}
+
+/// Create an image asset from the local path to the image
+#[allow(unused)]
+const fn image(path: &'static str) -> ImageAssetBuilder {
+    ImageAssetBuilder
+}
+
+/// A builder for a font asset. This must be used in the `mg!` macro.
+pub struct FontAssetBuilder;
+
+impl FontAssetBuilder {
+    /// Sets the font family of the font
+    #[allow(unused)]
+    pub const fn family(self, family: &'static str) -> Self {
+        Self
+    }
+
+    /// Sets the font weight of the font
+    #[allow(unused)]
+    pub const fn weights<const N: usize>(self, weights: [u32; N]) -> Self {
+        Self
+    }
+
+    /// Sets the subset of text that the font needs to support
+    #[allow(unused)]
+    pub const fn text(self, text: &'static str) -> Self {
+        Self
+    }
+
+    /// Sets the display of the font
+    #[allow(unused)]
+    pub const fn display(self, display: &'static str) -> Self {
+        Self
+    }
+}
+
+/// Create a font asset from the local path to the font
+#[allow(unused)]
+const fn font(path: &'static str) -> FontAssetBuilder {
+    FontAssetBuilder
+}
+
+/// A trait for something that can be used in the `mg!` macro
+pub trait ForMgMacro {}
+
+impl ForMgMacro for ImageAssetBuilder {}
+impl ForMgMacro for FontAssetBuilder {}
+impl ForMgMacro for &'static str {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,35 +74,60 @@ impl<'a> dioxus_core::prelude::IntoAttributeValue<'a> for ImageAsset {
     }
 }
 
+/// The type of an image
+#[derive(Debug, PartialEq, PartialOrd, Clone, Copy, Hash)]
+pub enum ImageType {
+    /// A png image
+    Png,
+    /// A jpg image
+    Jpg,
+    /// An avif image
+    Avif,
+    /// A webp image
+    Webp,
+}
+
 /// A builder for an image asset. This must be used in the `mg!` macro.
+///
+/// > **Note**: This will do nothing outside of the `mg!` macro
 pub struct ImageAssetBuilder;
 
 impl ImageAssetBuilder {
     /// Sets the preview of the image
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
-    pub const fn format(self, format: manganis_common::ImageType) -> Self {
+    pub const fn format(self, format: ImageType) -> Self {
         Self
     }
 
     /// Sets the size of the image
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
-    pub const fn size(self, size: Option<manganis_common::ImageType>) -> Self {
+    pub const fn size(self, x: u32, y: u32) -> Self {
         Self
     }
 
     /// Make the image use a low quality preview
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
     pub const fn low_quality_preview(self) -> Self {
         Self
     }
 
     /// Make the image preloaded
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
     pub const fn preload(self) -> Self {
         Self
     }
 
     /// Make the image URL encoded
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
     pub const fn url_encoded(self) -> Self {
         Self
@@ -110,48 +135,82 @@ impl ImageAssetBuilder {
 }
 
 /// Create an image asset from the local path to the image
+///
+/// > **Note**: This will do nothing outside of the `mg!` macro
 #[allow(unused)]
-const fn image(path: &'static str) -> ImageAssetBuilder {
+pub const fn image(path: &'static str) -> ImageAssetBuilder {
     ImageAssetBuilder
 }
 
 /// A builder for a font asset. This must be used in the `mg!` macro.
+///
+/// > **Note**: This will do nothing outside of the `mg!` macro
 pub struct FontAssetBuilder;
 
 impl FontAssetBuilder {
     /// Sets the font family of the font
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
-    pub const fn family(self, family: &'static str) -> Self {
+    pub const fn families<const N: usize>(self, families: [&'static str; N]) -> Self {
         Self
     }
 
     /// Sets the font weight of the font
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
     pub const fn weights<const N: usize>(self, weights: [u32; N]) -> Self {
         Self
     }
 
     /// Sets the subset of text that the font needs to support
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
     pub const fn text(self, text: &'static str) -> Self {
         Self
     }
 
     /// Sets the display of the font
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
     #[allow(unused)]
     pub const fn display(self, display: &'static str) -> Self {
         Self
     }
 }
 
-/// Create a font asset from the local path to the font
+/// Create a font asset
+///
+/// > **Note**: This will do nothing outside of the `mg!` macro
 #[allow(unused)]
-const fn font(path: &'static str) -> FontAssetBuilder {
+pub const fn font() -> FontAssetBuilder {
     FontAssetBuilder
 }
 
+/// Create an file asset from the local path or url to the file
+///
+/// > **Note**: This will do nothing outside of the `mg!` macro
+#[allow(unused)]
+pub const fn file(path: &'static str) -> ImageAssetBuilder {
+    ImageAssetBuilder
+}
+
 /// A trait for something that can be used in the `mg!` macro
-pub trait ForMgMacro {}
+///
+/// > **Note**: These types will do nothing outside of the `mg!` macro
+pub trait ForMgMacro: __private::Sealed + Sync + Send {}
+
+mod __private {
+    use super::*;
+
+    pub trait Sealed {}
+
+    impl Sealed for ImageAssetBuilder {}
+    impl Sealed for FontAssetBuilder {}
+    impl Sealed for &'static str {}
+}
 
 impl ForMgMacro for ImageAssetBuilder {}
 impl ForMgMacro for FontAssetBuilder {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub use manganis_macro::*;
 
-/// An image asset
+/// An image asset that is built by the [`mg!`] macro
 #[derive(Debug, PartialEq, PartialOrd, Clone, Hash)]
 pub struct ImageAsset {
     /// The path to the image
@@ -74,28 +74,34 @@ impl<'a> dioxus_core::prelude::IntoAttributeValue<'a> for ImageAsset {
     }
 }
 
-/// The type of an image
+/// The type of an image. You can read more about the tradeoffs between image formats [here](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types)
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy, Hash)]
 pub enum ImageType {
-    /// A png image
+    /// A png image. Png images cannot contain transparency and tend to compress worse than other formats
     Png,
-    /// A jpg image
+    /// A jpg image. Jpg images can contain transparency and tend to compress better than png images
     Jpg,
-    /// An avif image
-    Avif,
-    /// A webp image
+    /// A webp image. Webp images can contain transparency and tend to compress better than jpg images
     Webp,
+    /// An avif image. Avif images can compress slightly better than webp images but are not supported by all browsers
+    Avif,
 }
 
-/// A builder for an image asset. This must be used in the `mg!` macro.
+/// A builder for an image asset. This must be used in the [`mg!`] macro.
 ///
 /// > **Note**: This will do nothing outside of the `mg!` macro
 pub struct ImageAssetBuilder;
 
 impl ImageAssetBuilder {
-    /// Sets the preview of the image
+    /// Sets the format of the image
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// The choosing the right format can make your site load much faster. Webp and avif images tend to be a good default for most images
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(image("https://avatars.githubusercontent.com/u/79236386?s=48&v=4").format(ImageType::Webp));
+    /// ```
     #[allow(unused)]
     pub const fn format(self, format: ImageType) -> Self {
         Self
@@ -104,6 +110,12 @@ impl ImageAssetBuilder {
     /// Sets the size of the image
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// If you only use the image in one place, you can set the size of the image to the size it will be displayed at. This will make the image load faster
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(image("https://avatars.githubusercontent.com/u/79236386?s=48&v=4").size(512, 512));
+    /// ```
     #[allow(unused)]
     pub const fn size(self, x: u32, y: u32) -> Self {
         Self
@@ -112,6 +124,12 @@ impl ImageAssetBuilder {
     /// Make the image use a low quality preview
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// A low quality preview is a small version of the image that will load faster. This is useful for large images on mobile devices that may take longer to load
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(image("https://avatars.githubusercontent.com/u/79236386?s=48&v=4").low_quality_preview());
+    /// ```
     #[allow(unused)]
     pub const fn low_quality_preview(self) -> Self {
         Self
@@ -120,6 +138,12 @@ impl ImageAssetBuilder {
     /// Make the image preloaded
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// Preloading an image will make the image start to load as soon as possible. This is useful for images that will be displayed soon after the page loads or images that may not be visible immediately, but should start loading sooner
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(image("https://avatars.githubusercontent.com/u/79236386?s=48&v=4").preload());
+    /// ```
     #[allow(unused)]
     pub const fn preload(self) -> Self {
         Self
@@ -128,15 +152,38 @@ impl ImageAssetBuilder {
     /// Make the image URL encoded
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// URL encoding an image inlines the data of the image into the URL. This is useful for small images that should load as soon as the html is parsed
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(image("https://avatars.githubusercontent.com/u/79236386?s=48&v=4").url_encoded());
+    /// ```
     #[allow(unused)]
     pub const fn url_encoded(self) -> Self {
         Self
     }
 }
 
-/// Create an image asset from the local path to the image
+/// Create an image asset from the local path or url to the image
 ///
 /// > **Note**: This will do nothing outside of the `mg!` macro
+///
+/// You can collect images which will be automatically optimized with the image builder:
+/// ```rust
+/// const _: &str = manganis::mg!(image("./rustacean-flat-gesture.png"));
+/// ```
+/// Resize the image at compile time to make the assets file size smaller:
+/// ```rust
+/// const _: &str = manganis::mg!(image("./rustacean-flat-gesture.png").size(52, 52));
+/// ```
+/// Or convert the image at compile time to a web friendly format:
+/// ```rust
+/// const _: &str = manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageFormat::Avif).size(52, 52));
+/// ```
+/// You can mark images as preloaded to make them load faster in your app
+/// ```rust
+/// const _: &str = manganis::mg!(image("./rustacean-flat-gesture.png").preload());
+/// ```
 #[allow(unused)]
 pub const fn image(path: &'static str) -> ImageAssetBuilder {
     ImageAssetBuilder
@@ -151,6 +198,10 @@ impl FontAssetBuilder {
     /// Sets the font family of the font
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(font().families(["Roboto"]));
+    /// ```
     #[allow(unused)]
     pub const fn families<const N: usize>(self, families: [&'static str; N]) -> Self {
         Self
@@ -159,22 +210,34 @@ impl FontAssetBuilder {
     /// Sets the font weight of the font
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(font().families(["Roboto"]).weights([200]));
+    /// ```
     #[allow(unused)]
     pub const fn weights<const N: usize>(self, weights: [u32; N]) -> Self {
         Self
     }
 
-    /// Sets the subset of text that the font needs to support
+    /// Sets the subset of text that the font needs to support. The font will only include the characters in the text which can make the font file size significantly smaller
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(font().families(["Roboto"]).weights([200]).text("Hello, world!"));
+    /// ```
     #[allow(unused)]
     pub const fn text(self, text: &'static str) -> Self {
         Self
     }
 
-    /// Sets the display of the font
+    /// Sets the [display](https://www.w3.org/TR/css-fonts-4/#font-display-desc) of the font. The display control what happens when the font is unavailable
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(font().families(["Roboto"]).weights([200]).text("Hello, world!").display("swap"));
+    /// ```
     #[allow(unused)]
     pub const fn display(self, display: &'static str) -> Self {
         Self
@@ -184,6 +247,19 @@ impl FontAssetBuilder {
 /// Create a font asset
 ///
 /// > **Note**: This will do nothing outside of the `mg!` macro
+///
+/// You can use the font builder to collect fonts that will be included in the final binary from google fonts
+/// ```rust
+/// const _: &str = manganis::mg!(font().families(["Roboto"]));
+/// ```
+/// You can specify weights for the fonts
+/// ```rust
+/// const _: &str = manganis::mg!(font().families(["Roboto"]).weights([200]));
+/// ```
+/// Or set the text to only include the characters you need
+/// ```rust
+/// const _: &str = manganis::mg!(font().families(["Roboto"]).weights([200]).text("Hello, world!"));
+/// ```
 #[allow(unused)]
 pub const fn font() -> FontAssetBuilder {
     FontAssetBuilder
@@ -192,6 +268,15 @@ pub const fn font() -> FontAssetBuilder {
 /// Create an file asset from the local path or url to the file
 ///
 /// > **Note**: This will do nothing outside of the `mg!` macro
+///
+/// The file builder collects an arbitrary file. Relative paths are resolved relative to the package root
+/// ```rust
+/// const _: &str = manganis::mg!(file("./src/asset.txt"));
+/// ```
+/// Or you can use URLs to read the asset at build time from a remote location
+/// ```rust
+/// const _: &str = manganis::mg!(file("https://rustacean.net/assets/rustacean-flat-happy.png"));
+/// ```
 #[allow(unused)]
 pub const fn file(path: &'static str) -> ImageAssetBuilder {
     ImageAssetBuilder

--- a/test-package/src/main.rs
+++ b/test-package/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
 
     let class = manganis::classes!("p-10");
     assert_eq!(class, "p-10");
-    let path = manganis::file!("./test-package-dependency/src/asset.txt");
+    let path = manganis::mg!(file("./test-package-dependency/src/asset.txt"));
     println!("{}", path);
     assert!(path.starts_with("dist/asset"));
     println!("{}", IMAGE_ASSET);

--- a/test-package/test-package-dependency/src/file.rs
+++ b/test-package/test-package-dependency/src/file.rs
@@ -1,5 +1,5 @@
 const _: &str = manganis::classes!("flex flex-col p-5");
-pub const TEXT_ASSET: &str = manganis::file!("./src/asset.txt");
+pub const TEXT_ASSET: &str = manganis::mg!(file("./src/asset.txt"));
 pub const IMAGE_ASSET: &str =
-    manganis::file!("https://rustacean.net/assets/rustacean-flat-happy.png");
-pub const HTML_ASSET: &str = manganis::file!("https://github.com/DioxusLabs/dioxus");
+    manganis::mg!(file("https://rustacean.net/assets/rustacean-flat-happy.png"));
+pub const HTML_ASSET: &str = manganis::mg!(file("https://github.com/DioxusLabs/dioxus"));

--- a/test-package/test-package-dependency/src/file.rs
+++ b/test-package/test-package-dependency/src/file.rs
@@ -1,5 +1,6 @@
 const _: &str = manganis::classes!("flex flex-col p-5");
 pub const TEXT_ASSET: &str = manganis::mg!(file("./src/asset.txt"));
-pub const IMAGE_ASSET: &str =
-    manganis::mg!(file("https://rustacean.net/assets/rustacean-flat-happy.png"));
+pub const IMAGE_ASSET: &str = manganis::mg!(file(
+    "https://rustacean.net/assets/rustacean-flat-happy.png"
+));
 pub const HTML_ASSET: &str = manganis::mg!(file("https://github.com/DioxusLabs/dioxus"));

--- a/test-package/test-package-nested-dependency/src/file.rs
+++ b/test-package/test-package-nested-dependency/src/file.rs
@@ -6,12 +6,19 @@ pub const RESIZED_PNG_ASSET: manganis::ImageAsset =
 pub const JPEG_ASSET: manganis::ImageAsset =
     manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Jpg));
 pub const RESIZED_JPEG_ASSET: manganis::ImageAsset =
-    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Jpg).size(52, 52));
-pub const AVIF_ASSET: manganis::ImageAsset =
-    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Avif).low_quality_preview());
+    manganis::mg!(image("./rustacean-flat-gesture.png")
+        .format(ImageType::Jpg)
+        .size(52, 52));
+pub const AVIF_ASSET: manganis::ImageAsset = manganis::mg!(image("./rustacean-flat-gesture.png")
+    .format(ImageType::Avif)
+    .low_quality_preview());
 pub const RESIZED_AVIF_ASSET: manganis::ImageAsset =
-    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Avif).size(52, 52));
+    manganis::mg!(image("./rustacean-flat-gesture.png")
+        .format(ImageType::Avif)
+        .size(52, 52));
 pub const WEBP_ASSET: manganis::ImageAsset =
     manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Webp));
 pub const RESIZED_WEBP_ASSET: manganis::ImageAsset =
-    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Webp).size(52, 52));
+    manganis::mg!(image("./rustacean-flat-gesture.png")
+        .format(ImageType::Webp)
+        .size(52, 52));

--- a/test-package/test-package-nested-dependency/src/file.rs
+++ b/test-package/test-package-nested-dependency/src/file.rs
@@ -1,17 +1,17 @@
 const _: &str = manganis::classes!("flex flex-row p-5");
-pub const CSS_ASSET: &str = manganis::file!("./style.css");
-pub const PNG_ASSET: &str = manganis::file!("./rustacean-flat-gesture.png");
+pub const CSS_ASSET: &str = manganis::mg!(file("./style.css"));
+pub const PNG_ASSET: &str = manganis::mg!(file("./rustacean-flat-gesture.png"));
 pub const RESIZED_PNG_ASSET: manganis::ImageAsset =
-    manganis::image!("./rustacean-flat-gesture.png", { size: (52, 52) });
+    manganis::mg!(image("./rustacean-flat-gesture.png").size(52, 52));
 pub const JPEG_ASSET: manganis::ImageAsset =
-    manganis::image!("./rustacean-flat-gesture.png", { format: jpeg });
+    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Jpg));
 pub const RESIZED_JPEG_ASSET: manganis::ImageAsset =
-    manganis::image!("./rustacean-flat-gesture.png", { format: jpeg, size: (52, 52) });
+    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Jpg).size(52, 52));
 pub const AVIF_ASSET: manganis::ImageAsset =
-    manganis::image!("./rustacean-flat-gesture.png", { format: avif, low_quality_preview: true });
+    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Avif).low_quality_preview());
 pub const RESIZED_AVIF_ASSET: manganis::ImageAsset =
-    manganis::image!("./rustacean-flat-gesture.png", { format: avif, size: (52, 52) });
+    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Avif).size(52, 52));
 pub const WEBP_ASSET: manganis::ImageAsset =
-    manganis::image!("./rustacean-flat-gesture.png", { format: webp });
+    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Webp));
 pub const RESIZED_WEBP_ASSET: manganis::ImageAsset =
-    manganis::image!("./rustacean-flat-gesture.png", { format: webp, size: (52, 52) });
+    manganis::mg!(image("./rustacean-flat-gesture.png").format(ImageType::Webp).size(52, 52));

--- a/test-package/test-package-nested-dependency/src/font.rs
+++ b/test-package/test-package-nested-dependency/src/font.rs
@@ -1,6 +1,12 @@
-pub const ROBOTO_FONT: &str =
-    manganis::font!({ families: ["Roboto"], weights: [400], text: "hello world" });
-pub const COMFORTAA_FONT: &str =
-    manganis::font!({ families: ["Comfortaa"], weights: [300], text: "testing fonts" });
-pub const ROBOTO_FONT_LIGHT_FONT: &str =
-    manganis::font!({ families: ["Roboto"], weights: [200], text: "light font" });
+pub const ROBOTO_FONT: &str = manganis::mg!(font()
+    .families(["Roboto"])
+    .weights([400])
+    .text("hello world"));
+pub const COMFORTAA_FONT: &str = manganis::mg!(font()
+    .families(["Comfortaa"])
+    .weights([400])
+    .text("hello world"));
+pub const ROBOTO_FONT_LIGHT_FONT: &str = manganis::mg!(font()
+    .families(["Roboto"])
+    .weights([200])
+    .text("hello world"));


### PR DESCRIPTION
This switches assets within manganis to use the builder pattern in the macro instead of the struct-like macro we currently use.
```rust
// You can also collect arbitrary files. Relative paths are resolved relative to the package root
const _: &str = mg!("./src/asset.txt");
// You can use URLs to copy read the asset at build time
const _: &str = mg!("https://rustacean.net/assets/rustacean-flat-happy.png");

// You can collect images which will be automatically optimized
const _: &str = mg!(image("./rustacean-flat-gesture.png"));
// Resize the image at compile time to make the assets smaller
const _: &str = mg!(image("./rustacean-flat-gesture.png").size(52, 52));
// Or convert the image at compile time to a web friendly format
const _: &str = mg!(image("./rustacean-flat-gesture.png").format(ImageFormat::AVIF).size(52, 52));

// You can also collect google fonts
const _: &str = mg!(font().families(["Roboto"]));
// Specify weights for fonts to collect
const _: &str = mg!(font().families(["Comfortaa"]).weights([300]));
// Or specific text to include fonts for only the characters used in that text
const _: &str = mg!(font().families(["Roboto"]).weights([200]).text("light font"));
```
The builder only works within the macro. This changes the configuration to look like normal rust code. The only limitation is you need to only use constants for the parameters which is enforced by the macro.
This includes documentation on the structs/functions that the macro uses which show up inline with autocomplete as you type in the macro.

This also enables autocomplete and autocorrect for the macro:
<img width="1123" alt="Screenshot_2023-12-12_at_9 16 44_AM" src="https://github.com/DioxusLabs/collect-assets/assets/66571940/6b20219c-751c-47df-aad4-522cde673d6b">
<img width="1123" alt="Screenshot_2023-12-12_at_9 17 12_AM" src="https://github.com/DioxusLabs/collect-assets/assets/66571940/027f2094-7005-4fa7-ab87-f7d17083c8c0">
