### PR TITLE
Fix overlapping assets in examples

### DIFF
--- a/cli-support/examples/cli.rs
+++ b/cli-support/examples/cli.rs
@@ -26,7 +26,7 @@ fn main() {
         .unwrap();
 
     // Then collect the assets
-    let manifest = AssetManifest::load();
+    let manifest = AssetManifest::load(Some("test-package"));
 
     // Remove the old assets
     let _ = std::fs::remove_dir_all(assets_file_location);

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -21,20 +21,36 @@ pub(crate) fn config_path() -> PathBuf {
 pub(crate) fn current_package_identifier() -> String {
     package_identifier(
         &std::env::var("CARGO_PKG_NAME").unwrap(),
+        std::env::var("CARGO_BIN_NAME").ok().as_deref(),
         &current_package_version(),
     )
 }
 
 /// The identifier for a package used to cache assets
-pub fn package_identifier(package: &str, version: &str) -> String {
-    package.to_string() + "-" + version
+pub fn package_identifier(package: &str, bin: 
+    Option<&str>
+    , version: &str) -> String {
+    let mut string = package.to_string();
+    if let Some(bin) = bin {
+        string.push('-');
+        string.push_str(bin);
+    }
+    string.push('-');
+    string.push_str(version);
+    string
 }
 
 /// Like `package_identifier`, but appends the identifier to the given path
-pub fn push_package_cache_dir(package: &str, version: impl Display, dir: &mut PathBuf) {
+pub fn push_package_cache_dir(package: &str, 
+    bin: Option<&str>,
+    version: impl Display, dir: &mut PathBuf) {
     let as_string = dir.as_mut_os_string();
     as_string.write_char(std::path::MAIN_SEPARATOR).unwrap();
     as_string.write_str(package).unwrap();
+    if let Some(bin) = bin {
+        as_string.write_char('-').unwrap();
+        as_string.write_str(bin).unwrap();
+    }
     as_string.write_char('-').unwrap();
     as_string.write_fmt(format_args!("{}", version)).unwrap();
 }

--- a/test-package/src/main.rs
+++ b/test-package/src/main.rs
@@ -9,10 +9,9 @@ fn main() {
     tracing_subscriber::fmt::init();
 
     println!(
-        "low quality preview: {:?}",
-        test_package_dependency::AVIF_ASSET.preview()
+        "{:?}",
+        test_package_dependency::AVIF_ASSET
     );
-    assert!(test_package_dependency::AVIF_ASSET.preview().is_some());
 
     // This is the location where the assets will be copied to in the filesystem
     let assets_file_location = "./dist/";
@@ -25,7 +24,7 @@ fn main() {
         .save();
 
     // Then collect the assets
-    let manifest = AssetManifest::load();
+    let manifest = AssetManifest::load(Some("test-package"));
 
     // Remove the old assets
     let _ = std::fs::remove_dir_all(assets_file_location);


### PR DESCRIPTION
This PR adds a section to the cache path for the current binary to fix overlapping assets in examples. This will make two different examples for the same package have a unique path because the binary is different