### PR TITLE
Add tracing, asset caching and fix binary package assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,7 @@ dependencies = [
  "reqwest",
  "serde",
  "toml 0.7.8",
+ "tracing",
  "url",
 ]
 
@@ -1206,6 +1207,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/cli-support/src/file.rs
+++ b/cli-support/src/file.rs
@@ -18,6 +18,9 @@ pub fn process_file(file: &FileAsset, output_folder: &Path) -> anyhow::Result<()
 
 impl Process for FileOptions {
     fn process(&self, input_location: &FileLocation, output_folder: &Path) -> anyhow::Result<()> {
+        if output_folder.join(input_location.unique_name()).exists() {
+            return Ok(());
+        }
         match self {
             Self::Other { .. } => {
                 let mut output_location = output_folder.to_path_buf();

--- a/cli-support/src/manifest.rs
+++ b/cli-support/src/manifest.rs
@@ -80,14 +80,11 @@ impl AssetManifestExt for AssetManifest {
             }
         }
         self.packages().par_iter().try_for_each(|package| {
-            tracing::info!("Copying static assets for package {}", package.package());
+            tracing::trace!("Copying static assets for package {}", package.package());
             package.assets().par_iter().try_for_each(|asset| {
                 if let AssetType::File(file_asset) = asset {
-                    tracing::info!(
-                        "Copying static asset from {:?} to {:?}",
-                        file_asset,
-                        location
-                    );
+                    tracing::info!("Optimizing and bundling {}", file_asset);
+                    tracing::trace!("Copying asset from {:?} to {:?}", file_asset, location);
                     match process_file(file_asset, &location) {
                         Ok(_) => {}
                         Err(err) => {
@@ -151,7 +148,7 @@ fn collect_dependencies(
             tracing::error!("Failed to read asset cache directory: {}", err);
         }
     }
-    tracing::info!(
+    tracing::trace!(
         "Found packages with assets: {:?}",
         packages.iter().cloned().collect::<Vec<_>>().join(", ")
     );

--- a/cli-support/src/manifest.rs
+++ b/cli-support/src/manifest.rs
@@ -145,6 +145,7 @@ fn collect_dependencies(
             tracing::error!("Failed to read asset cache directory: {}", err);
         }
     }
+    tracing::info!("Found {} packages with assets: {:?}", packages.len(), packages);
 
     let mut packages_to_visit = vec![root_package_id];
     let mut dependency_path = PathBuf::new();

--- a/cli-support/src/manifest.rs
+++ b/cli-support/src/manifest.rs
@@ -1,13 +1,13 @@
 pub use railwind::warning::Warning as TailwindWarning;
 use rustc_hash::FxHashSet;
-use std::path::{Path, PathBuf};
+use std::{fmt::Write, path::{Path, PathBuf}};
 
 use cargo_lock::{
     dependency::{self, graph::NodeIndex},
     Lockfile,
 };
 use manganis_common::{
-    cache::asset_cache_dir, cache::push_package_cache_dir, AssetManifest, AssetType, PackageAssets,
+    cache::{asset_cache_dir, push_package_identifier}, AssetManifest, AssetType, PackageAssets,
 };
 use petgraph::visit::EdgeRef;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
@@ -151,11 +151,13 @@ fn collect_dependencies(
         // Add the assets for this dependency
         dependency_path.clear();
         dependency_path.push(cache_dir);
-        push_package_cache_dir(
+        let os_string = dependency_path.as_mut_os_string();
+        os_string.write_char(std::path::MAIN_SEPARATOR).unwrap();
+        push_package_identifier(
             package.name.as_str(),
             bin.filter(|_| package_id == root_package_id),
             &package.version,
-            &mut dependency_path,
+            os_string,
         );
         tracing::trace!("Looking for assets in {}", dependency_path.display());
         dependency_path.push("assets.toml");

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,6 +22,7 @@ infer = "0.11.0"
 # Remote assets
 url = { version = "2.4.0", features = ["serde"] }
 reqwest = { version = "0.11.18", features = ["blocking"] }
+tracing = "0.1.40"
 
 [features]
 html = []

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -34,9 +34,14 @@ pub enum FileSource {
 
 impl Display for FileSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Local(path) => write!(f, "{}", path.display()),
-            Self::Remote(url) => write!(f, "{}", url.as_str()),
+        let as_string = match self {
+            Self::Local(path) => path.display().to_string(),
+            Self::Remote(url) => url.as_str().to_string(),
+        };
+        if as_string.len() > 25 {
+            write!(f, "{}...", &as_string[..25])
+        } else {
+            write!(f, "{}", as_string)
         }
     }
 }

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Display,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
     str::FromStr,
@@ -29,6 +30,15 @@ pub enum FileSource {
     Local(PathBuf),
     /// A remote file
     Remote(Url),
+}
+
+impl Display for FileSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Local(path) => write!(f, "{}", path.display()),
+            Self::Remote(url) => write!(f, "{}", url.as_str()),
+        }
+    }
 }
 
 impl FileSource {
@@ -266,6 +276,23 @@ pub struct FileAsset {
     location: FileLocation,
     options: FileOptions,
     url_encoded: bool,
+}
+
+impl Display for FileAsset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let url_encoded = if self.url_encoded {
+            " [url encoded]"
+        } else {
+            ""
+        };
+        write!(
+            f,
+            "{} [{}]{}",
+            self.location.source(),
+            self.options,
+            url_encoded
+        )
+    }
 }
 
 impl FileAsset {

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -27,7 +27,7 @@ pub(crate) fn current_package_identifier() -> String {
 }
 
 /// The identifier for a package used to cache assets
-pub fn package_identifier(package: &str, bin: Option<&str>, version: &str) -> String {
+pub fn package_identifier(package: &str, bin: Option<&str>, version: impl Display) -> String {
     let mut id = String::new();
     push_package_identifier(package, bin, version, &mut id);
     id

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -28,32 +28,25 @@ pub(crate) fn current_package_identifier() -> String {
 
 /// The identifier for a package used to cache assets
 pub fn package_identifier(package: &str, bin: Option<&str>, version: &str) -> String {
-    let mut string = package.to_string();
-    if let Some(bin) = bin {
-        string.push('-');
-        string.push_str(bin);
-    }
-    string.push('-');
-    string.push_str(version);
-    string
+    let mut id = String::new();
+    push_package_identifier(package, bin, version, &mut id);
+    id
 }
 
-/// Like `package_identifier`, but appends the identifier to the given path
-pub fn push_package_cache_dir(
+/// Like `package_identifier`, but appends the identifier to the given writer
+pub fn push_package_identifier(
     package: &str,
     bin: Option<&str>,
     version: impl Display,
-    dir: &mut PathBuf,
+    to: &mut impl Write,
 ) {
-    let as_string = dir.as_mut_os_string();
-    as_string.write_char(std::path::MAIN_SEPARATOR).unwrap();
-    as_string.write_str(package).unwrap();
+    to.write_str(package).unwrap();
     if let Some(bin) = bin {
-        as_string.write_char('-').unwrap();
-        as_string.write_str(bin).unwrap();
+        to.write_char('-').unwrap();
+        to.write_str(bin).unwrap();
     }
-    as_string.write_char('-').unwrap();
-    as_string.write_fmt(format_args!("{}", version)).unwrap();
+    to.write_char('-').unwrap();
+    to.write_fmt(format_args!("{}", version)).unwrap();
 }
 
 pub(crate) fn current_package_version() -> String {
@@ -66,6 +59,20 @@ pub(crate) fn manifest_dir() -> PathBuf {
 
 pub(crate) fn current_package_cache_dir() -> PathBuf {
     let mut dir = asset_cache_dir();
+    dir.push(current_package_identifier());
+    dir
+}
+
+/// The location where logs are stored while expanding macros
+pub fn macro_log_directory() -> PathBuf {
+    let mut dir = asset_cache_dir();
+    dir.push("logs");
+    dir
+}
+
+/// The current log file for the macro expansion
+pub fn macro_log_file() -> PathBuf {
+    let mut dir = macro_log_directory();
     dir.push(current_package_identifier());
     dir
 }

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -22,7 +22,7 @@ pub(crate) fn current_package_identifier() -> String {
     package_identifier(
         &std::env::var("CARGO_PKG_NAME").unwrap(),
         std::env::var("CARGO_BIN_NAME").ok().as_deref(),
-        &current_package_version(),
+        current_package_version(),
     )
 }
 

--- a/common/src/file.rs
+++ b/common/src/file.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 /// The options for a file asset
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Hash)]
@@ -14,6 +14,18 @@ pub enum FileOptions {
     Css(CssOptions),
     /// Any other asset
     Other(UnknownFileOptions),
+}
+
+impl Display for FileOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Image(options) => write!(f, "{}", options),
+            Self::Video(options) => write!(f, "{}", options),
+            Self::Font(options) => write!(f, "{}", options),
+            Self::Css(options) => write!(f, "{}", options),
+            Self::Other(options) => write!(f, "{}", options),
+        }
+    }
 }
 
 impl FileOptions {
@@ -75,6 +87,23 @@ pub struct ImageOptions {
     size: Option<(u32, u32)>,
     preload: bool,
     ty: ImageType,
+}
+
+impl Display for ImageOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some((x, y)) = self.size {
+            write!(f, "{} ({}x{})", self.ty, x, y)?;
+        } else {
+            write!(f, "{}", self.ty)?;
+        }
+        if self.compress {
+            write!(f, " (compressed)")?;
+        }
+        if self.preload {
+            write!(f, " (preload)")?;
+        }
+        Ok(())
+    }
 }
 
 impl ImageOptions {
@@ -142,6 +171,17 @@ pub enum ImageType {
     Webp,
 }
 
+impl Display for ImageType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Png => write!(f, "png"),
+            Self::Jpg => write!(f, "jpg"),
+            Self::Avif => write!(f, "avif"),
+            Self::Webp => write!(f, "webp"),
+        }
+    }
+}
+
 impl FromStr for ImageType {
     type Err = ();
 
@@ -163,6 +203,16 @@ pub struct VideoOptions {
     compress: bool,
     /// The type of the video
     ty: VideoType,
+}
+
+impl Display for VideoOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.ty)?;
+        if self.compress {
+            write!(f, " (compressed)")?;
+        }
+        Ok(())
+    }
 }
 
 impl VideoOptions {
@@ -203,10 +253,26 @@ pub enum VideoType {
     GIF,
 }
 
+impl Display for VideoType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MP4 => write!(f, "mp4"),
+            Self::Webm => write!(f, "webm"),
+            Self::GIF => write!(f, "gif"),
+        }
+    }
+}
+
 /// The options for a font asset
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Hash)]
 pub struct FontOptions {
     ty: FontType,
+}
+
+impl Display for FontOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.ty)
+    }
 }
 
 impl FontOptions {
@@ -232,10 +298,29 @@ pub enum FontType {
     WOFF2,
 }
 
+impl Display for FontType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TTF => write!(f, "ttf"),
+            Self::WOFF => write!(f, "woff"),
+            Self::WOFF2 => write!(f, "woff2"),
+        }
+    }
+}
+
 /// The options for a css asset
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Hash)]
 pub struct CssOptions {
     minify: bool,
+}
+
+impl Display for CssOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.minify {
+            write!(f, "minified")?;
+        }
+        Ok(())
+    }
 }
 
 impl CssOptions {
@@ -260,6 +345,15 @@ impl Default for CssOptions {
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Hash)]
 pub struct UnknownFileOptions {
     extension: Option<String>,
+}
+
+impl Display for UnknownFileOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(extension) = &self.extension {
+            write!(f, "{}", extension)?;
+        }
+        Ok(())
+    }
 }
 
 impl UnknownFileOptions {

--- a/common/src/package.rs
+++ b/common/src/package.rs
@@ -9,6 +9,7 @@ use crate::{
 pub fn clear_assets() -> std::io::Result<()> {
     let dir = current_package_cache_dir();
     if dir.exists() {
+        tracing::info!("Clearing assets in {:?}", dir);
         std::fs::remove_dir_all(dir)?;
     }
     Ok(())
@@ -18,6 +19,7 @@ pub fn clear_assets() -> std::io::Result<()> {
 pub fn add_asset(asset: AssetType) -> std::io::Result<AssetType> {
     let mut dir = current_package_cache_dir();
     dir.push("assets.toml");
+    tracing::info!("Adding asset {:?} to {:?}", asset, dir);
     let mut package_assets: PackageAssets = if dir.exists() {
         let contents = std::fs::read_to_string(&dir)?;
         toml::from_str(&contents).unwrap_or_else(|_| PackageAssets {

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -19,6 +19,7 @@ syn = { version = "2.0", features = ["full", "extra-traits"] }
 manganis-common = { path = "../common", version = "0.2.1" }
 manganis-cli-support = { path = "../cli-support", version = "0.2.1", optional = true }
 base64 = { version = "0.21.5", optional = true }
+tracing-subscriber = "0.3.18"
 
 [features]
 url-encoding = ["manganis-cli-support", "base64"]

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -31,9 +31,7 @@ fn trace_to_file() {
             .truncate(true)
             .open(path)
             .unwrap();
-        tracing_subscriber::fmt::fmt()
-            .with_writer(file)
-            .init();
+        tracing_subscriber::fmt::fmt().with_writer(file).init();
     }
 }
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -4,6 +4,7 @@
 use file::FileAssetParser;
 use font::FontAssetParser;
 use image::ImageAssetParser;
+use manganis_common::cache::macro_log_file;
 use manganis_common::{AssetType, MetadataAsset, TailwindAsset};
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
@@ -17,13 +18,31 @@ mod file;
 mod font;
 mod image;
 
+static LOG_FILE_FRESH: AtomicBool = AtomicBool::new(false);
+
+fn trace_to_file() {
+    // If this is the first time the macro is used in the crate, set the subscriber to write to a file
+    if !LOG_FILE_FRESH.fetch_or(true, Ordering::Relaxed) {
+        let path = macro_log_file();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .unwrap();
+        tracing_subscriber::fmt::fmt()
+            .with_writer(file)
+            .init();
+    }
+}
+
 // It appears rustc uses one instance of the dynamic library for each crate that uses it.
 // We can reset the asset of the current crate the first time the macro is used in the crate.
 static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 fn add_asset(asset: manganis_common::AssetType) -> std::io::Result<AssetType> {
-    if !INITIALIZED.load(Ordering::Relaxed) {
-        INITIALIZED.store(true, Ordering::Relaxed);
+    if !INITIALIZED.fetch_or(true, Ordering::Relaxed) {
         manganis_common::clear_assets()?;
     }
 
@@ -39,6 +58,8 @@ fn add_asset(asset: manganis_common::AssetType) -> std::io::Result<AssetType> {
 /// ```
 #[proc_macro]
 pub fn classes(input: TokenStream) -> TokenStream {
+    trace_to_file();
+
     let input_as_str = parse_macro_input!(input as LitStr);
     let input_as_str = input_as_str.value();
 
@@ -117,6 +138,8 @@ pub fn classes(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn mg(input: TokenStream) -> TokenStream {
+    trace_to_file();
+
     let builder_tokens = {
         let input = input.clone();
         parse_macro_input!(input as TokenStream2)
@@ -204,6 +227,8 @@ impl Parse for MetadataValue {
 /// ```
 #[proc_macro]
 pub fn meta(input: TokenStream) -> TokenStream {
+    trace_to_file();
+
     let md = parse_macro_input!(input as MetadataValue);
 
     let result = add_asset(manganis_common::AssetType::Metadata(MetadataAsset::new(


### PR DESCRIPTION
This PR adds tracing to make manganis easier to debug, caches assets by file name and hash and fixes binary package assets. Binary package assets were not handled correctly in the first quick filter manganis does to check if the package has any assets