### PR TITLE
improve error message when asset does not exist

### DIFF
--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -281,7 +281,7 @@ impl Display for AssetError {
                        manifest_dir.display()
                 ),
             AssetError::NotFile(absolute_path) =>
-                write!(f, "`{}` is not a file, please choose a valid asset.", absolute_path.display()),
+                write!(f, "`{}` is not a file, please choose a valid asset.\nAry relative paths are resolved relative to the manifest directory.", absolute_path.display()),
             AssetError::IO(absolute_path, err) =>
                 write!(f, "unknown error when accessing `{}`: \n{}", absolute_path.display(), err)
         }

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -276,12 +276,12 @@ impl Display for AssetError {
             AssetError::NotFoundAbsolute(x) =>
                 write!(f,"File `{}` not found, please make sure it exists", x.display()),
             AssetError::NotFoundRelative(manifest_dir, path) =>
-                write!(f,"cannot find file `{}` in `{}`, please make sure the file exists.\nAny relative paths are resolved relative to the manifest directory.", 
+                write!(f,"cannot find file `{}` in `{}`, please make sure it exists.\nAny relative paths are resolved relative to the manifest directory.", 
                        path,
                        manifest_dir.display()
                 ),
             AssetError::NotFile(absolute_path) =>
-                write!(f, "`{}` is not a file, please choose a valid asset.\nAry relative paths are resolved relative to the manifest directory.", absolute_path.display()),
+                write!(f, "`{}` is not a file, please choose a valid asset.\nAny relative paths are resolved relative to the manifest directory.", absolute_path.display()),
             AssetError::IO(absolute_path, err) =>
                 write!(f, "unknown error when accessing `{}`: \n{}", absolute_path.display(), err)
         }

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -257,8 +257,39 @@ impl FileLocation {
     }
 }
 
+/// Error while checking an asset exists
+#[derive(Debug)]
+pub enum AssetError {
+    /// The absolute path does not exist
+    NotFoundAbsolute(PathBuf),
+    /// The relative path does not exist
+    NotFoundRelative(PathBuf, String),
+    /// The path exist but is not a file
+    NotFile(PathBuf),
+    /// Unknown IO error
+    IO(PathBuf, String),
+}
+
+impl Display for AssetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AssetError::NotFoundAbsolute(x) =>
+                write!(f,"File `{}` not found, please make sure it exists", x.display()),
+            AssetError::NotFoundRelative(manifest_dir, path) =>
+                write!(f,"cannot find file `{}` in `{}`, please make sure the file exists.\nAny relative paths are resolved relative to the manifest directory.", 
+                       path,
+                       manifest_dir.display()
+                ),
+            AssetError::NotFile(absolute_path) =>
+                write!(f, "`{}` is not a file, please choose a valid asset.", absolute_path.display()),
+            AssetError::IO(absolute_path, err) =>
+                write!(f, "unknown error when accessing `{}`: \n{}", absolute_path.display(), err)
+        }
+    }
+}
+
 impl FromStr for FileSource {
-    type Err = anyhow::Error;
+    type Err = AssetError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match Url::parse(s) {
@@ -266,10 +297,23 @@ impl FromStr for FileSource {
             Err(_) => {
                 let manifest_dir = manifest_dir();
                 let path = manifest_dir.join(PathBuf::from(s));
-                let path = path
-                    .canonicalize()
-                    .with_context(|| format!("Failed to canonicalize path: {}", path.display()))?;
-                Ok(Self::Local(path))
+                let is_absolute = PathBuf::from(s).is_absolute();
+
+                match path.canonicalize() {
+                    Ok(x) if x.is_file() => Ok(Self::Local(x)),
+                    // path exists but is not a file
+                    Ok(x) => Err(AssetError::NotFile(x)),
+                    // absolute path does not exist
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound && is_absolute => {
+                        Err(AssetError::NotFoundAbsolute(s.into()))
+                    }
+                    // relative path does not exist
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        Err(AssetError::NotFoundRelative(manifest_dir, s.into()))
+                    }
+                    // other error
+                    Err(e) => Err(AssetError::IO(path, e.to_string())),
+                }
             }
         }
     }

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -267,7 +267,7 @@ pub enum AssetError {
     /// The path exist but is not a file
     NotFile(PathBuf),
     /// Unknown IO error
-    IO(PathBuf, String),
+    IO(PathBuf, std::io::Error),
 }
 
 impl Display for AssetError {
@@ -312,7 +312,7 @@ impl FromStr for FileSource {
                         Err(AssetError::NotFoundRelative(manifest_dir, s.into()))
                     }
                     // other error
-                    Err(e) => Err(AssetError::IO(path, e.to_string())),
+                    Err(e) => Err(AssetError::IO(path, e)),
                 }
             }
         }

--- a/macro/src/file.rs
+++ b/macro/src/file.rs
@@ -15,12 +15,14 @@ impl Parse for FileAssetParser {
         let path = inside.parse::<syn::LitStr>()?;
 
         let path_as_str = path.value();
-        let path = match path_as_str.parse(){
+        let path = match path_as_str.parse() {
             Ok(path) => path,
-            Err(e) => return Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
-                format!("Failed to parse path: {path_as_str}\nAny relative paths are resolved relative to the manifest directory\n{e}"),
-            ))
+            Err(e) => {
+                return Err(syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    format!("{e}"),
+                ))
+            }
         };
         let this_file = FileAsset::new(path);
         let asset =

--- a/macro/src/image.rs
+++ b/macro/src/image.rs
@@ -180,10 +180,10 @@ impl Parse for ImageAssetParser {
         let path_as_str = path.value();
         let path: FileSource = match path_as_str.parse() {
             Ok(path) => path,
-            Err(_) => {
+            Err(e) => {
                 return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
-                    format!("Failed to parse path: {}", path_as_str),
+                    format!("{e}"),
                 ))
             }
         };


### PR DESCRIPTION
This PR address #19 by giving a more precise error message.

Here are example error messages I get now:

When `mg!(file("test.tx"))` does not exist:
```
error: cannot find file `test.tx` in `/home/rambip/proj/dioxus-test`, please make sure it exists.
       Any relative paths are resolved relative to the manifest directory.
```

When `mg!(file("/home/user/project/foo"))` does not exist:
```
error: File `/home/user/project/foo` not found, please make sure it exists
```

When `mg!(image(".."))` is not a file:
```
error: `/home/rambip/proj` is not a file, please choose a valid asset.
       Any relative paths are resolved relative to the manifest directory.
```