### PR TITLE
Don't Automatically Delete Script

### DIFF
--- a/cli-support/src/linker_intercept.rs
+++ b/cli-support/src/linker_intercept.rs
@@ -125,7 +125,7 @@ where
     }
 
     cmd.spawn()?.wait()?;
-    delete_linker_script().unwrap();
+    _ = delete_linker_script();
     Ok(())
 }
 

--- a/cli-support/src/linker_intercept.rs
+++ b/cli-support/src/linker_intercept.rs
@@ -125,7 +125,6 @@ where
     }
 
     cmd.spawn()?.wait()?;
-    _ = delete_linker_script();
     Ok(())
 }
 
@@ -171,7 +170,7 @@ fn create_linker_script(exec: PathBuf, subcommand: &str) -> Result<PathBuf, std:
 }
 
 /// Deletes the temporary script created by [`create_linker_script`].
-fn delete_linker_script() -> Result<(), std::io::Error> {
+pub fn delete_linker_script() -> Result<(), std::io::Error> {
     #[cfg(windows)]
     let ext = "bat";
     #[cfg(not(windows))]


### PR DESCRIPTION
This PR makes the `delete_linker_script` function public and removes automatic deletions of the linker script handing over control to the dev-user. 


Use-case: Fullstack platform builds Web & Desktop and the script gets deleted before the other build can use it.