### PR TITLE
Fix link section name when cross compiling

### DIFF
--- a/cli-support/tests/collects_assets.rs
+++ b/cli-support/tests/collects_assets.rs
@@ -44,7 +44,7 @@ fn build() {
     println!("running the CLI from {test_package_dir:?}");
 
     // Then build your application
-    let args = ["--release"];
+    let args = ["--target", "wasm32-unknown-unknown", "--release"];
     Command::new("cargo")
         .arg("build")
         .args(args)

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -5,11 +5,11 @@ use serde::{Deserialize, Serialize};
 use crate::cache::config_path;
 
 fn default_assets_serve_location() -> String {
-    #[cfg(target_os = "wasm")]
+    #[cfg(target_arch = "wasm32")]
     {
         "/".to_string()
     }
-    #[cfg(not(target_os = "wasm"))]
+    #[cfg(not(target_arch = "wasm32"))]
     {
         "./assets/".to_string()
     }

--- a/common/src/linker.rs
+++ b/common/src/linker.rs
@@ -4,95 +4,72 @@
 //! name conventions used by the linker on different platforms.
 //! This is used to make the "link_section" magic working
 
-/// section name used by the linker on this platform
-pub const SECTION: &str = {
-    #[cfg(any(
-        target_os = "none",
-        target_os = "linux",
-        target_os = "android",
-        target_os = "fuchsia",
-        target_os = "psp",
-        target_os = "freebsd",
-        target_os = "wasm"
-    ))]
-    {
-        "manganis"
-    }
+/// Information about the manganis link section for a given platform
+#[derive(Debug, Clone, Copy)]
+pub struct LinkSection {
+    /// The link section we pass to the static
+    pub link_section: &'static str,
+    /// The name of the section we find in the binary
+    pub name: &'static str,
+}
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-    {
-        "__DATA,manganis,regular,no_dead_strip"
-    }
+impl LinkSection {
+    /// The list of link sections for all supported platforms
+    pub const ALL: &'static [&'static LinkSection] =
+        &[Self::WASM, Self::MACOS, Self::WINDOWS, Self::ILLUMOS];
 
-    #[cfg(target_os = "windows")]
-    {
-        "mg"
-    }
+    /// Returns the link section used in linux, android, fuchsia, psp, freebsd, and wasm32
+    pub const WASM: &'static LinkSection = &LinkSection {
+        link_section: "manganis",
+        name: "manganis",
+    };
 
-    #[cfg(target_os = "illumos")]
-    {
-        "set_manganis"
-    }
-};
+    /// Returns the link section used in macOS, iOS, tvOS
+    pub const MACOS: &'static LinkSection = &LinkSection {
+        link_section: "__DATA,manganis,regular,no_dead_strip",
+        name: "manganis",
+    };
 
-/// The name of the section used by the linker on this platform
-pub const SECTION_NAME: &str = {
-    #[cfg(any(
-        target_os = "none",
-        target_os = "linux",
-        target_os = "android",
-        target_os = "fuchsia",
-        target_os = "psp",
-        target_os = "freebsd",
-        target_os = "wasm"
-    ))]
-    {
-        "manganis"
-    }
+    /// Returns the link section used in windows
+    pub const WINDOWS: &'static LinkSection = &LinkSection {
+        link_section: "mg",
+        name: "mg",
+    };
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-    {
-        "manganis"
-    }
+    /// Returns the link section used in illumos
+    pub const ILLUMOS: &'static LinkSection = &LinkSection {
+        link_section: "set_manganis",
+        name: "set_manganis",
+    };
 
-    #[cfg(target_os = "windows")]
-    {
-        "mg"
-    }
+    /// The link section used on the current platform
+    pub const CURRENT: &'static LinkSection = {
+        #[cfg(any(
+            target_os = "none",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "psp",
+            target_os = "freebsd",
+            target_arch = "wasm32"
+        ))]
+        {
+            Self::WASM
+        }
 
-    #[cfg(target_os = "illumos")]
-    {
-        "set_manganis"
-    }
-};
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        {
+            Self::MACOS
+        }
 
-// section name used by the linker on this platform
-// pub const SECTION_START: &str = {
-//     #[cfg(any(
-//         target_os = "none",
-//         target_os = "linux",
-//         target_os = "android",
-//         target_os = "fuchsia",
-//         target_os = "psp",
-//         target_os = "freebsd",
-//         target_os = "wasm"
-//     ))]
-//     {
-//         "__start_manganis"
-//     }
+        #[cfg(target_os = "windows")]
+        {
+            Self::WINDOWS
+        }
 
-//     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-//     {
-//         "\x01section$start$__DATA$manganis"
-//     }
-
-//     #[cfg(target_os = "windows")]
-//     {
-//         "mg_s"
-//     }
-
-//     #[cfg(target_os = "illumos")]
-//     {
-//         "__start_set_manganis"
-//     }
-// };
+        #[cfg(target_os = "illumos")]
+        {
+            Self::ILLUMOS
+        }
+    };
+}

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -49,7 +49,10 @@ fn generate_link_section(asset: manganis_common::AssetType) -> TokenStream2 {
 
     let asset_bytes = syn::LitByteStr::new(asset_description.as_bytes(), position);
 
-    let section_name = syn::LitStr::new(manganis_common::linker::SECTION, position);
+    let section_name = syn::LitStr::new(
+        manganis_common::linker::LinkSection::CURRENT.link_section,
+        position,
+    );
 
     quote! {
         #[link_section = #section_name]


### PR DESCRIPTION
When cross compiling to another platform, this PR changes the CLI to look for link sections that match any platform, not just the current platform.

This fixes assets when compiling to WASM on MacOs